### PR TITLE
Basic screen name

### DIFF
--- a/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
@@ -37,19 +37,21 @@ public class MainActivity extends AppCompatActivity {
     }
 
     public void onButtonClick(View v) {
-        EditText conferenceName = findViewById(R.id.conferenceName);
-        String conferenceNameStr = conferenceName.getText().toString();
-        System.out.println(conferenceNameStr);
+        // extract screen name and conference name from EditText fields
         EditText screenName = findViewById(R.id.screenName);
         String screenNameStr = screenName.getText().toString();
+        EditText conferenceName = findViewById(R.id.conferenceName);
+        String conferenceNameStr = conferenceName.getText().toString();
 
-        Bundle userInfoBundle = new Bundle();
-        if (screenNameStr.length() > 0) {
-            Log.d("SCREEN_NAME", screenNameStr);
-            userInfoBundle.putString("displayName", screenNameStr);
-        }
-
+        // join conference if a conference name has been entered
         if (conferenceNameStr.length() > 0) {
+            // populate user Bundle if a screen name has been entered
+            Bundle userInfoBundle = new Bundle();
+            if (screenNameStr.length() > 0) {
+                Log.d("SCREEN_NAME", screenNameStr);
+                userInfoBundle.putString("displayName", screenNameStr);
+            }
+
             JitsiMeetConferenceOptions options
                     = new JitsiMeetConferenceOptions.Builder()
                     .setRoom(conferenceNameStr)

--- a/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
@@ -1,7 +1,10 @@
 package com.thinqtv.thinqtv_android;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
+import android.os.PersistableBundle;
 import android.util.Log;
 import android.view.View;
 import android.widget.EditText;
@@ -57,5 +60,19 @@ public class MainActivity extends AppCompatActivity {
                     .build();
             JitsiMeetActivity.launch(this, options);
         }
+    }
+
+    @Override
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState, @Nullable PersistableBundle persistentState) {
+        super.onCreate(savedInstanceState, persistentState);
+
+        
     }
 }

--- a/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
@@ -1,10 +1,7 @@
 package com.thinqtv.thinqtv_android;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
-import android.os.PersistableBundle;
 import android.util.Log;
 import android.view.View;
 import android.widget.EditText;
@@ -60,19 +57,5 @@ public class MainActivity extends AppCompatActivity {
                     .build();
             JitsiMeetActivity.launch(this, options);
         }
-    }
-
-    @Override
-    protected void onSaveInstanceState(@NonNull Bundle outState) {
-        super.onSaveInstanceState(outState);
-
-
-    }
-
-    @Override
-    public void onCreate(@Nullable Bundle savedInstanceState, @Nullable PersistableBundle persistentState) {
-        super.onCreate(savedInstanceState, persistentState);
-
-        
     }
 }

--- a/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
@@ -2,12 +2,14 @@ package com.thinqtv.thinqtv_android;
 
 import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.EditText;
 
 import org.jitsi.meet.sdk.JitsiMeet;
 import org.jitsi.meet.sdk.JitsiMeetActivity;
 import org.jitsi.meet.sdk.JitsiMeetConferenceOptions;
+import org.jitsi.meet.sdk.JitsiMeetUserInfo;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -35,14 +37,23 @@ public class MainActivity extends AppCompatActivity {
     }
 
     public void onButtonClick(View v) {
-        EditText editText = findViewById(R.id.conferenceName);
-        String text = editText.getText().toString();
-        System.out.println(text);
+        EditText conferenceName = findViewById(R.id.conferenceName);
+        String conferenceNameStr = conferenceName.getText().toString();
+        System.out.println(conferenceNameStr);
+        EditText screenName = findViewById(R.id.screenName);
+        String screenNameStr = screenName.getText().toString();
 
-        if (text.length() > 0) {
+        Bundle userInfoBundle = new Bundle();
+        if (screenNameStr.length() > 0) {
+            Log.d("SCREEN_NAME", screenNameStr);
+            userInfoBundle.putString("displayName", screenNameStr);
+        }
+
+        if (conferenceNameStr.length() > 0) {
             JitsiMeetConferenceOptions options
                     = new JitsiMeetConferenceOptions.Builder()
-                    .setRoom(text)
+                    .setRoom(conferenceNameStr)
+                    .setUserInfo(new JitsiMeetUserInfo(userInfoBundle))
                     .build();
             JitsiMeetActivity.launch(this, options);
         }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,24 +11,21 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="80dp"
         android:layout_marginEnd="16dp"
         android:ems="10"
         android:hint="@string/conference_name_hint"
+        android:importantForAutofill="no"
         android:inputType="textPersonName"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.496"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
 
-        android:importantForAutofill="no"/>
+        app:layout_constraintTop_toBottomOf="@+id/screenName" />
 
     <Button
         android:id="@+id/joinButton"
         android:layout_width="147dp"
         android:layout_height="45dp"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
         android:onClick="onButtonClick"
         android:text="@string/join_button_hint"
@@ -36,5 +33,17 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/conferenceName" />
+
+    <EditText
+        android:id="@+id/screenName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:ems="10"
+        android:hint="@string/screen_name_hint"
+        android:inputType="textPersonName"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">ThinQ TV</string>
     <string name="conference_name_hint">Enter Room Name</string>
     <string name="join_button_hint">Join</string>
+    <string name="screen_name_hint">Enter Your Name</string>
 </resources>


### PR DESCRIPTION
Added the ability to set the screen name from our home screen, rather than having the user be prompted for it after they're already in the meeting. You last screen name will persist even after closing and reopening the app, though it doesn't yet show up in the EditText field when you do so.