### PR TITLE
Screen name persistence

### DIFF
--- a/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
@@ -45,11 +45,18 @@ public class MainActivity extends AppCompatActivity {
 
         Log.d("SCREEN_NAME", "~~onCreate");
         if (savedInstanceState != null) {
-            Log.d("SCREEN_NAME", "~~~~savedInstanceState wasn't null");
+            Log.d("SCREEN_NAME", "~~~~savedInstanceState wasn't null: " +
+                    savedInstanceState.getString(screenNameKey));
             lastScreenNameStr = savedInstanceState.getString(screenNameKey);
-            EditText screenName = findViewById(R.id.screenName);
-            screenName.setText(lastScreenNameStr);
         }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        EditText screenName = findViewById(R.id.screenName);
+        screenName.setText(lastScreenNameStr);
     }
 
     // Button listener for "Join Conversation" button that connects to default ThinQ.TV chatroom

--- a/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
@@ -53,7 +53,10 @@ public class MainActivity extends AppCompatActivity {
         super.onResume();
 
         EditText screenName = findViewById(R.id.screenName);
-        screenName.setText(lastScreenNameStr);
+        String screenNameStr = screenName.getText().toString();
+        if (screenNameStr.length() == 0) {
+            screenName.setText(lastScreenNameStr);
+        }
     }
 
     // Button listener for "Join Conversation" button that connects to default ThinQ.TV chatroom

--- a/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
@@ -43,7 +43,9 @@ public class MainActivity extends AppCompatActivity {
                 .build();
         JitsiMeet.setDefaultConferenceOptions(defaultOptions);
 
+        Log.d("SCREEN_NAME", "~~onCreate");
         if (savedInstanceState != null) {
+            Log.d("SCREEN_NAME", "~~~~savedInstanceState wasn't null");
             lastScreenNameStr = savedInstanceState.getString(screenNameKey);
             EditText screenName = findViewById(R.id.screenName);
             screenName.setText(lastScreenNameStr);
@@ -79,6 +81,7 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState, @NonNull PersistableBundle outPersistentState) {
+        Log.d("SCREEN_NAME", "~~onSaveInstanceState");
         if (lastScreenNameStr.length() > 0) {
             outState.putString(screenNameKey, lastScreenNameStr);
         }

--- a/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
@@ -20,7 +20,7 @@ import java.net.URL;
 
 public class MainActivity extends AppCompatActivity {
     private static final String URL_STR = "https://meet.jit.si";
-    private static final String THINQTV_ROOM_NAME = "ThinqTV";
+    private static final String THINQTV_ROOM_NAME = "trevorroom";
     private static final String screenNameKey = "com.thinqtv.thinqtv_android.SCREEN_NAME";;
     private static String lastScreenNameStr = "";
 
@@ -80,12 +80,12 @@ public class MainActivity extends AppCompatActivity {
     }
 
     @Override
-    public void onSaveInstanceState(@NonNull Bundle outState, @NonNull PersistableBundle outPersistentState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         Log.d("SCREEN_NAME", "~~onSaveInstanceState");
         if (lastScreenNameStr.length() > 0) {
             outState.putString(screenNameKey, lastScreenNameStr);
         }
 
-        super.onSaveInstanceState(outState, outPersistentState);
+        super.onSaveInstanceState(outState);
     }
 }

--- a/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
@@ -20,8 +20,8 @@ import java.net.URL;
 
 public class MainActivity extends AppCompatActivity {
     private static final String URL_STR = "https://meet.jit.si";
-    private static final String THINQTV_ROOM_NAME = "trevorroom";
-    private static final String screenNameKey = "com.thinqtv.thinqtv_android.SCREEN_NAME";;
+    private static final String THINQTV_ROOM_NAME = "ThinqTV";
+    private static final String screenNameKey = "com.thinqtv.thinqtv_android.SCREEN_NAME";
     private static String lastScreenNameStr = "";
 
     @Override
@@ -43,10 +43,7 @@ public class MainActivity extends AppCompatActivity {
                 .build();
         JitsiMeet.setDefaultConferenceOptions(defaultOptions);
 
-        Log.d("SCREEN_NAME", "~~onCreate");
         if (savedInstanceState != null) {
-            Log.d("SCREEN_NAME", "~~~~savedInstanceState wasn't null: " +
-                    savedInstanceState.getString(screenNameKey));
             lastScreenNameStr = savedInstanceState.getString(screenNameKey);
         }
     }
@@ -72,6 +69,7 @@ public class MainActivity extends AppCompatActivity {
         if (lastScreenNameStr.length() > 0) {
             Log.d("SCREEN_NAME", lastScreenNameStr);
             Bundle userInfoBundle = new Bundle();
+            // the string "displayName" is required by the API
             userInfoBundle.putString("displayName", lastScreenNameStr);
             optionsBuilder.setUserInfo(new JitsiMeetUserInfo(userInfoBundle));
         }
@@ -88,7 +86,6 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
-        Log.d("SCREEN_NAME", "~~onSaveInstanceState");
         if (lastScreenNameStr.length() > 0) {
             outState.putString(screenNameKey, lastScreenNameStr);
         }

--- a/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
@@ -1,9 +1,11 @@
 package com.thinqtv.thinqtv_android;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.PersistableBundle;
 import android.util.Log;
 import android.view.View;
 import android.widget.EditText;
@@ -19,6 +21,8 @@ import java.net.URL;
 public class MainActivity extends AppCompatActivity {
     private static final String URL_STR = "https://meet.jit.si";
     private static final String THINQTV_ROOM_NAME = "ThinqTV";
+    private static final String screenNameKey = "com.thinqtv.thinqtv_android.SCREEN_NAME";;
+    private static String lastScreenNameStr = "";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -38,22 +42,28 @@ public class MainActivity extends AppCompatActivity {
                 .setWelcomePageEnabled(false)
                 .build();
         JitsiMeet.setDefaultConferenceOptions(defaultOptions);
+
+        if (savedInstanceState != null) {
+            lastScreenNameStr = savedInstanceState.getString(screenNameKey);
+            EditText screenName = findViewById(R.id.screenName);
+            screenName.setText(lastScreenNameStr);
+        }
     }
 
     // Button listener for "Join Conversation" button that connects to default ThinQ.TV chatroom
     public void onJoinClick(View v) {
         // extract screen name and conference name from EditText fields
         EditText screenName = findViewById(R.id.screenName);
-        String screenNameStr = screenName.getText().toString();
+        lastScreenNameStr = screenName.getText().toString();
 
         JitsiMeetConferenceOptions.Builder optionsBuilder
                 = new JitsiMeetConferenceOptions.Builder()
                 .setRoom(THINQTV_ROOM_NAME);
 
-        if (screenNameStr.length() > 0) {
-            Log.d("SCREEN_NAME", screenNameStr);
+        if (lastScreenNameStr.length() > 0) {
+            Log.d("SCREEN_NAME", lastScreenNameStr);
             Bundle userInfoBundle = new Bundle();
-            userInfoBundle.putString("displayName", screenNameStr);
+            userInfoBundle.putString("displayName", lastScreenNameStr);
             optionsBuilder.setUserInfo(new JitsiMeetUserInfo(userInfoBundle));
         }
 
@@ -65,5 +75,14 @@ public class MainActivity extends AppCompatActivity {
     public void goGetInvolved(View V){
         Intent i = new Intent(this, GetInvolved.class);
         startActivity(i);
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState, @NonNull PersistableBundle outPersistentState) {
+        if (lastScreenNameStr.length() > 0) {
+            outState.putString(screenNameKey, lastScreenNameStr);
+        }
+
+        super.onSaveInstanceState(outState, outPersistentState);
     }
 }


### PR DESCRIPTION
This restores the screen name field to the last value that was entered when the 'Join' button was pressed in situations where it would otherwise become blank, such as after pressing the back button or restarting the phone. It only saves things to disk when necessary, otherwise just saving the last screen name in memory.