### PR TITLE
Fix app duplication

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,12 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".GetInvolvedApplyNowPage"></activity>
+        <activity android:name=".ConferenceActivity"
+            android:supportsPictureInPicture="true"
+            android:configChanges=
+                "screenSize|smallestScreenSize|screenLayout|orientation"
+            ></activity>
+        <activity android:name=".GetInvolvedApplyNowPage" />
         <activity android:name=".GetInvolved" />
         <activity android:name=".MainActivity">
             <intent-filter>

--- a/app/src/main/java/com/thinqtv/thinqtv_android/ConferenceActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/ConferenceActivity.java
@@ -1,0 +1,46 @@
+package com.thinqtv.thinqtv_android;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.content.Intent;
+import android.os.Bundle;
+
+import org.jitsi.meet.sdk.JitsiMeet;
+import org.jitsi.meet.sdk.JitsiMeetActivity;
+import org.jitsi.meet.sdk.JitsiMeetConferenceOptions;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class ConferenceActivity extends JitsiMeetActivity {
+    private static final String URL_STR = "https://meet.jit.si";
+
+    @Override
+    protected void initialize() {
+        URL serverURL;
+        try {
+            serverURL = new URL(URL_STR);
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Invalid server URL.");
+        }
+
+        JitsiMeetConferenceOptions defaultOptions
+                = new JitsiMeetConferenceOptions.Builder()
+                .setServerURL(serverURL)
+                .setWelcomePageEnabled(false)
+                .setFeatureFlag("pip.enabled", true)
+                .build();
+        JitsiMeet.setDefaultConferenceOptions(defaultOptions);
+
+        super.initialize();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+
+        // return to the main activity
+        startActivity(new Intent(this, MainActivity.class));
+    }
+}

--- a/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
@@ -17,27 +17,12 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 public class MainActivity extends AppCompatActivity {
-    private static final String URL_STR = "https://meet.jit.si";
     private static final String THINQTV_ROOM_NAME = "ThinqTV";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        URL serverURL;
-
-        try {
-            serverURL = new URL(URL_STR);
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-            throw new RuntimeException("Invalid server URL.");
-        }
-        JitsiMeetConferenceOptions defaultOptions
-                = new JitsiMeetConferenceOptions.Builder()
-                .setServerURL(serverURL)
-                .setWelcomePageEnabled(false)
-                .build();
-        JitsiMeet.setDefaultConferenceOptions(defaultOptions);
     }
 
     // Button listener for "Join Conversation" button that connects to default ThinQ.TV chatroom
@@ -58,7 +43,13 @@ public class MainActivity extends AppCompatActivity {
         }
 
         JitsiMeetConferenceOptions options = optionsBuilder.build();
-        JitsiMeetActivity.launch(this, options);
+
+        // build and start intent to start a jitsi meet conference
+        Intent intent = new Intent(getApplicationContext(), ConferenceActivity.class);
+        intent.setAction("org.jitsi.meet.CONFERENCE");
+        intent.putExtra("JitsiMeetConferenceOptions", options);
+        startActivity(intent);
+        finish();
     }
 
     // go to get involved page


### PR DESCRIPTION
The main activity destroys itself when joining the conference (which now has its own activity), and the conference navigates back to the main activity when it is finished. PIP works perfectly.