### PR TITLE
Remove red box at top of Invite Us To Speak

### DIFF
--- a/app/src/main/java/com/thinqtv/thinqtv_android/GetInvolved.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/GetInvolved.java
@@ -76,6 +76,8 @@ public class GetInvolved extends AppCompatActivity implements AdapterView.OnItem
                     webpageViewer.loadUrl("javascript:(window.onload = function() { " +
                             "(navBar = document.getElementsByTagName('nav')[0]); navBar.parentNode.removeChild(navBar);" +
                             "(footer = document.getElementsByTagName('footer')[0]); footer.parentNode.removeChild(footer);" +
+                            // remove the red box at the top of the page
+                            "(label = document.getElementsByClassName('box')[0]); label.parentNode.removeChild(label);" +
                             "})()");
                 } catch (Exception e) {
                     e.printStackTrace();


### PR DESCRIPTION
Removed the red box at the top of the Invite Us To Speak page for now because the email address has some formatting issues on some devices.