### PR TITLE
Get screen name from user info, remember users.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,7 +43,6 @@ dependencies {
     implementation 'com.facebook.android:facebook-android-sdk:[5,6)'
     implementation 'com.facebook.android:facebook-login:[5,6)'
     implementation 'com.google.android.gms:play-services-auth:18.1.0'
-    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
 
     implementation 'com.google.code.gson:gson:2.8.6'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,4 +44,6 @@ dependencies {
     implementation 'com.facebook.android:facebook-login:[5,6)'
     implementation 'com.google.android.gms:play-services-auth:18.1.0'
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
+
+    implementation 'com.google.code.gson:gson:2.8.6'
 }

--- a/app/src/main/java/com/thinqtv/thinqtv_android/AccountSettingsActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/AccountSettingsActivity.java
@@ -9,6 +9,8 @@ import android.widget.EditText;
 import com.thinqtv.thinqtv_android.data.UserRepository;
 import com.thinqtv.thinqtv_android.data.model.LoggedInUser;
 
+import java.util.HashMap;
+
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
@@ -24,14 +26,14 @@ public class AccountSettingsActivity extends AppCompatActivity {
         ActionBar actionBar = getSupportActionBar();
         actionBar.setDisplayHomeAsUpEnabled(true);
 
-        LoggedInUser user = UserRepository.getInstance().getLoggedInUser();
+        HashMap<String, String> userInfo = UserRepository.getInstance().getLoggedInUser().getUserInfo();
         EditText email = findViewById(R.id.email);
-        email.setText(user.getEmail());
+        email.setText(userInfo.get("email"));
         EditText currentPassword = findViewById(R.id.current_password);
         EditText newPassword = findViewById(R.id.new_password);
         EditText newPasswordConfirm = findViewById(R.id.new_password_confirm);
         EditText permalink = findViewById(R.id.permalink);
-        permalink.setText(user.getPermalink());
+        permalink.setText(userInfo.get("permalink"));
         Button sendButton = findViewById(R.id.send);
         Context context = this;
         sendButton.setOnClickListener(view -> {

--- a/app/src/main/java/com/thinqtv/thinqtv_android/AddEventActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/AddEventActivity.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.os.Bundle;
 import android.text.format.DateFormat;
 import android.util.Log;
+import android.view.MenuItem;
 import android.widget.Button;
 import android.widget.DatePicker;
 import android.widget.EditText;
@@ -34,7 +35,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.DialogFragment;
 
 public class AddEventActivity extends AppCompatActivity{
@@ -45,6 +48,10 @@ public class AddEventActivity extends AppCompatActivity{
         Calendar calendar = Calendar.getInstance();
         calendar.set(Calendar.SECOND, 0);
         setContentView(R.layout.activity_add_event);
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        ActionBar actionBar = getSupportActionBar();
+        actionBar.setDisplayHomeAsUpEnabled(true);
         Button setTimeButton = findViewById(R.id.time);
         setTimeButton.setOnClickListener(view -> {
             DialogFragment newFragment = new TimePickerFragment((view1, hour, minute) -> {
@@ -180,6 +187,17 @@ public class AddEventActivity extends AppCompatActivity{
             }
         };
         DataSource.getInstance().addToRequestQueue(request, context);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                this.finish();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
     }
 }
 

--- a/app/src/main/java/com/thinqtv/thinqtv_android/ConferenceActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/ConferenceActivity.java
@@ -32,12 +32,4 @@ public class ConferenceActivity extends JitsiMeetActivity {
 
         super.initialize();
     }
-
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-
-        // return to the main activity
-        startActivity(new Intent(this, MainActivity.class));
-    }
 }

--- a/app/src/main/java/com/thinqtv/thinqtv_android/ProfileSettingsActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/ProfileSettingsActivity.java
@@ -14,11 +14,16 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
 
+import com.google.gson.JsonObject;
 import com.thinqtv.thinqtv_android.data.UserRepository;
 import com.thinqtv.thinqtv_android.data.model.LoggedInUser;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.io.InputStream;
 import java.net.URL;
+import java.util.HashMap;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
@@ -41,20 +46,24 @@ public class ProfileSettingsActivity extends AppCompatActivity {
         ActionBar actionBar = getSupportActionBar();
         actionBar.setDisplayHomeAsUpEnabled(true);
 
-        LoggedInUser user = UserRepository.getInstance().getLoggedInUser();
+        HashMap<String, String> userInfo = UserRepository.getInstance().getLoggedInUser().getUserInfo();
         EditText name = findViewById(R.id.name);
-        name.setText(user.getName());
+        name.setText(userInfo.get("name"));
         EditText about = findViewById(R.id.about_you);
-        about.setText(user.getAbout());
+        about.setText(userInfo.get("about"));
         EditText topic1 = findViewById(R.id.topic_1);
-        topic1.setText(user.getGenre1());
+        topic1.setText(userInfo.get("genre1"));
         EditText topic2 = findViewById(R.id.topic_2);
-        topic2.setText(user.getGenre2());
+        topic2.setText(userInfo.get("genre2"));
         EditText topic3 = findViewById(R.id.topic_3);
-        topic3.setText(user.getGenre3());
+        topic3.setText(userInfo.get("genre3"));
 
-        new DownloadImageTask(findViewById(R.id.profile_image_view)).execute(user.getProfilePic());
-        new DownloadImageTask(findViewById(R.id.banner_image_view)).execute(user.getBannerPic());
+        if (userInfo.get("profilepic") != null) {
+            new DownloadImageTask(findViewById(R.id.profile_image_view)).execute(userInfo.get("profilepic"));
+        }
+        if (userInfo.get("bannerpic") != null) {
+            new DownloadImageTask(findViewById(R.id.banner_image_view)).execute(userInfo.get("bannerpic"));
+        }
 
         imageView = null;
         Button profileImageButton = findViewById(R.id.choose_image_button);

--- a/app/src/main/java/com/thinqtv/thinqtv_android/conversation_fragment.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/conversation_fragment.java
@@ -49,8 +49,6 @@ import java.util.TimeZone;
 
 public class conversation_fragment extends Fragment {
     private static final String THINQTV_ROOM_NAME = "ThinqTV";
-    private static final String screenNameKey = "com.thinqtv.thinqtv_android.SCREEN_NAME";
-    private static String lastScreenNameStr = "";
 
     private ActionBarDrawerToggle mDrawerToggle; //toggle for sidebar button shown in action bar
 
@@ -80,59 +78,6 @@ public class conversation_fragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
 
         initializeEvents();
-
-        // If a user is logged in, use their name. Otherwise, try to find a name elsewhere.
-        if (UserRepository.getInstance().isLoggedIn()) {
-            lastScreenNameStr = UserRepository.getInstance().getLoggedInUser().getName();
-        }
-        else {
-            // restore screen name using lastInstanceState if possible
-            if (savedInstanceState != null) {
-                lastScreenNameStr = savedInstanceState.getString(screenNameKey);
-            }
-            // else try to restore it using SharedPreferences
-            else {
-                SharedPreferences sharedPref = getActivity().getPreferences(Context.MODE_PRIVATE);
-                String defaultValue = lastScreenNameStr;
-                lastScreenNameStr = sharedPref.getString(screenNameKey, defaultValue);
-            }
-        }
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-
-        // Check if a user has logged in, and if so, set the screen name.
-        if (UserRepository.getInstance().isLoggedIn()) {
-            lastScreenNameStr = UserRepository.getInstance().getLoggedInUser().getName();
-        }
-        // Otherwise, restore text inside screen name field if the user hasn't typed anything to override it
-        else {
-            //TODO: SHOULD ANYTHING HAPPEN IF THE APP IS OPENED AND THE USER IS NOT LOGGED IN?
-        }
-    }
-
-    @Override
-    public void onDestroy() {
-        if (lastScreenNameStr.length() > 0) {
-            SharedPreferences sharedPref = getActivity().getPreferences(Context.MODE_PRIVATE);
-            SharedPreferences.Editor editor = sharedPref.edit();
-            editor.putString(screenNameKey, lastScreenNameStr);
-            editor.commit();
-        }
-
-        super.onDestroy();
-    }
-
-    @Override
-    public void onSaveInstanceState(@NonNull Bundle outState) {
-        // save lastScreenNameStr to savedInstanceState if it exists
-        if (lastScreenNameStr.length() > 0) {
-            outState.putString(screenNameKey, lastScreenNameStr);
-        }
-
-        super.onSaveInstanceState(outState);
     }
 
     // Button listener for "Join Conversation" button that connects to default ThinQ.TV chatroom
@@ -141,13 +86,9 @@ public class conversation_fragment extends Fragment {
                 = new JitsiMeetConferenceOptions.Builder()
                 .setRoom(THINQTV_ROOM_NAME);
 
-        if (lastScreenNameStr.length() > 0) {
-            Log.d("SCREEN_NAME", lastScreenNameStr);
-            Bundle userInfoBundle = new Bundle();
-            // the string "displayName" is required by the API
-            userInfoBundle.putString("displayName", lastScreenNameStr);
-            optionsBuilder.setUserInfo(new JitsiMeetUserInfo(userInfoBundle));
-        }
+        Bundle userInfoBundle = new Bundle();
+        userInfoBundle.putString("displayName", UserRepository.getInstance().getLoggedInUser().getName());
+        optionsBuilder.setUserInfo(new JitsiMeetUserInfo(userInfoBundle));
 
         JitsiMeetConferenceOptions options = optionsBuilder.build();
 

--- a/app/src/main/java/com/thinqtv/thinqtv_android/conversation_fragment.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/conversation_fragment.java
@@ -87,7 +87,7 @@ public class conversation_fragment extends Fragment {
                 .setRoom(THINQTV_ROOM_NAME);
 
         Bundle userInfoBundle = new Bundle();
-        userInfoBundle.putString("displayName", UserRepository.getInstance().getLoggedInUser().getName());
+        userInfoBundle.putString("displayName", UserRepository.getInstance().getLoggedInUser().getUserInfo().get("name"));
         optionsBuilder.setUserInfo(new JitsiMeetUserInfo(userInfoBundle));
 
         JitsiMeetConferenceOptions options = optionsBuilder.build();
@@ -354,10 +354,7 @@ public class conversation_fragment extends Fragment {
 
     public void getEventsJSONfile()
     {
-        // where you get the JSON file
-        final String url = "https://thinq.tv/api/v1/events";
-
-        JsonArrayRequest request = new JsonArrayRequest(Request.Method.GET, url, null, new Response.Listener<JSONArray>() {
+        JsonArrayRequest request = new JsonArrayRequest(Request.Method.GET, getString(R.string.events_url), null, new Response.Listener<JSONArray>() {
             @Override
             public void onResponse(JSONArray response) {
                 // If you receive a response, the JSON data is saved in response

--- a/app/src/main/java/com/thinqtv/thinqtv_android/conversation_fragment.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/conversation_fragment.java
@@ -97,7 +97,6 @@ public class conversation_fragment extends Fragment {
         intent.setAction("org.jitsi.meet.CONFERENCE");
         intent.putExtra("JitsiMeetConferenceOptions", options);
         startActivity(intent);
-        getActivity().finish();
     }
 
     // listener for when a user clicks an event to go to its page

--- a/app/src/main/java/com/thinqtv/thinqtv_android/data/UserRepository.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/data/UserRepository.java
@@ -196,14 +196,7 @@ public class UserRepository {
         SharedPreferences pref = activity.getSharedPreferences("ACCOUNT", MODE_PRIVATE);
         String authToken = pref.getString("token", null);
 
-        JSONObject userLogin = new JSONObject();
-        JSONObject loginParams = new JSONObject();
-        try {
-            loginParams.put("email", email);
-            loginParams.put("token", authToken);
-            userLogin.put("user", loginParams);
-        } catch(JSONException e) { // Couldn't form JSON object for request.
-            e.printStackTrace();
+        if (authToken == null) {
             activity.finish();
             return;
         }
@@ -288,6 +281,12 @@ public class UserRepository {
                     params.put("genre3", topic3);
                 }
                 return params;
+            }
+            public Map<String, String> getHeaders() throws AuthFailureError {
+                Map<String, String> headers = super.getHeaders();
+                headers = new HashMap<>();
+                headers.put("Authorization", "Bearer " + getLoggedInUser().getUserInfo().get("token"));
+                return headers;
             }
             protected Map<String, DataPart> getByteData() {
                 Map<String, DataPart> params = new HashMap<>();

--- a/app/src/main/java/com/thinqtv/thinqtv_android/data/UserRepository.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/data/UserRepository.java
@@ -6,13 +6,17 @@ import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.util.Log;
 import android.widget.ImageView;
 
+import com.android.volley.AuthFailureError;
 import com.android.volley.NetworkResponse;
 import com.android.volley.Request;
 import com.android.volley.Response;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.JsonObjectRequest;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import com.thinqtv.thinqtv_android.R;
 import com.thinqtv.thinqtv_android.StartupLoadingActivity;
 import com.thinqtv.thinqtv_android.data.model.LoggedInUser;
@@ -88,7 +92,8 @@ public class UserRepository {
                 response -> {
                     try {
                         JSONObject user = new JSONObject(response.getString("user"));
-                        setLoggedInUser(new LoggedInUser(context, response.getString("token"), user.getString("name"), user.getString("permalink")));
+                        user.put("token", response.getString("token"));
+                        setLoggedInUser(new LoggedInUser(context, new Gson().fromJson(user.toString(), HashMap.class)));
                         loginViewModel.setResult(new Result<>(null, true));
                     } catch(JSONException e) {
                         e.printStackTrace();
@@ -136,7 +141,8 @@ public class UserRepository {
                 response -> {
                     try {
                         JSONObject user = new JSONObject(response.getString("user"));
-                        setLoggedInUser(new LoggedInUser(context, response.getString("token"), user.getString("name"), user.getString("permalink")));
+                        user.put("token", response.getString("token"));
+                        setLoggedInUser(new LoggedInUser(context, new Gson().fromJson(user.toString(), HashMap.class)));
                         registerViewModel.setResult(new Result<>(null, true));
                     } catch(JSONException e) {
                         e.printStackTrace();
@@ -188,7 +194,6 @@ public class UserRepository {
     public void loadSavedUser(StartupLoadingActivity activity) {
 
         SharedPreferences pref = activity.getSharedPreferences("ACCOUNT", MODE_PRIVATE);
-        String email = pref.getString("email", null);
         String authToken = pref.getString("token", null);
 
         JSONObject userLogin = new JSONObject();
@@ -203,20 +208,26 @@ public class UserRepository {
             return;
         }
 
-        JsonObjectRequest request = new JsonObjectRequest(Request.Method.POST,
-                activity.getResources().getString(R.string.login_url), userLogin,
-                response -> {
-                    try {
-                        setLoggedInUser(new LoggedInUser(activity, response.getString("name"), response.getString("token"), response.getString("permalink")));
-                        getLoggedInUser().updateAccount(response.getString("email"), response.getString("permalink"));
-                        getLoggedInUser().updateProfile(response.getString("name"), response.getString("profpic"),
-                                response.getString("about"), response.getString("genre1"), response.getString("genre2"),
-                                response.getString("genre3"), response.getString("bannerpic"));
-                    } catch(JSONException e) {
-                        e.printStackTrace();
-                    }
-                    activity.finish();
-                }, error -> activity.finish());
+        JsonObjectRequest request = new JsonObjectRequest(Request.Method.GET,
+                activity.getResources().getString(R.string.users_url), new JSONObject(), response -> {
+            try {
+                response.put("token", authToken);
+                setLoggedInUser(new LoggedInUser(activity, new Gson().fromJson(response.toString(), HashMap.class)));
+            } catch(JSONException e) {
+                e.printStackTrace();
+            }
+            activity.finish();
+        }, error -> {
+            activity.finish();
+        }) {
+            @Override
+            public Map<String, String> getHeaders() throws AuthFailureError {
+                Map<String, String> headers = super.getHeaders();
+                headers = new HashMap<>();
+                headers.put("Authorization", "Bearer " + authToken);
+                return headers;
+            }
+        };
 
         DataSource.getInstance().addToRequestQueue(request, activity);
     }
@@ -225,8 +236,6 @@ public class UserRepository {
                        String newPasswordConfirm, String permalink) {
         JSONObject params = new JSONObject();
         try {
-            params.put("user_email", getLoggedInUser().getEmail());
-            params.put("user_token", getLoggedInUser().getAuthToken());
             params.put("email", email);
             params.put("current_password", currentPassword);
             params.put("password", newPassword);
@@ -235,36 +244,24 @@ public class UserRepository {
         } catch (JSONException e) {
             e.printStackTrace();
         }
-        String url = context.getResources().getString(R.string.users_url) + "/" + UserRepository.getInstance().getLoggedInUser().getName();
+        String url = context.getResources().getString(R.string.users_url) + "/" + getLoggedInUser().getUserInfo().get("permalink");
         JsonObjectRequest request = new JsonObjectRequest(Request.Method.PUT, url, params, response -> {
-            try {
-                getLoggedInUser().updateToken(response.getString("token"));
-                getLoggedInUser().updateAccount(response.getString("email"), response.getString("permalink"));
-                ((Activity)context).finish();
-            } catch (JSONException e) {
-                e.printStackTrace();
-            }
+            getLoggedInUser().updateUserInfo(new Gson().fromJson(response.toString(), HashMap.class));
+            ((Activity)context).finish();
             }, error -> {
+            error.printStackTrace();
         });
         DataSource.getInstance().addToRequestQueue(request, context);
     }
     public void updateProfile(Context context, String name, ImageView profilePic, String about, String topic1,
                        String topic2, String topic3, ImageView bannerPic) {
-        String url = context.getResources().getString(R.string.users_url) + "/" + UserRepository.getInstance().getLoggedInUser().getName();
+        String url = context.getResources().getString(R.string.users_url) + "/" + getLoggedInUser().getUserInfo().get("permalink");
         VolleyMultipartRequest request = new VolleyMultipartRequest(Request.Method.PUT, url,
                 response -> {
                     String responseString = new String(response.data);
                     try {
                         JSONObject result = new JSONObject(responseString);
-                        getLoggedInUser().updateToken(result.getString("token"));
-                        getLoggedInUser().updateProfile(result.getString("name"), result.getString("profpic"),
-                                result.getString("about"), result.getString("genre1"), result.getString("genre2"),
-                                result.getString("genre3"), result.getString("bannerpic"));
-                        if (result.has("name")) {
-                            getLoggedInUser().setName(result.getString("name"));
-                        }
-                        if (result.has("pic")) {
-                        }
+                        getLoggedInUser().updateUserInfo(new Gson().fromJson(user.toString(), HashMap.class));
                         ((Activity)context).finish();
                     } catch (JSONException e) {
                         e.printStackTrace();
@@ -275,9 +272,6 @@ public class UserRepository {
                 }) {
             protected Map<String, String> getParams() {
                 Map<String, String> params = new HashMap<>();
-                params.put("user_email", UserRepository.getInstance().getLoggedInUser().getEmail());
-                params.put("user_token", UserRepository.getInstance().getLoggedInUser().getAuthToken());
-
                 if (!name.equals("")) {
                     params.put("name", name);
                 }

--- a/app/src/main/java/com/thinqtv/thinqtv_android/data/model/LoggedInUser.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/data/model/LoggedInUser.java
@@ -6,78 +6,34 @@ import android.content.SharedPreferences;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static android.content.Context.MODE_PRIVATE;
 
 public class LoggedInUser {
 
-    private String name;
-    private String authToken;
-    private String permalink;
-    private String email;
     private final SharedPreferences pref;
-    private String profilePic;
-    private String about;
-    private String genre1;
-    private String genre2;
-    private String genre3;
-    private String bannerPic;
+    private HashMap<String, String> userInfo;
 
-    public LoggedInUser(Context context, String authToken, String name, String permalink) {
-        this.authToken = authToken;
-        this.permalink = permalink;
-        this.email = email;
+    public LoggedInUser(Context context, HashMap<String, String> userInfo) {
+        this.userInfo = userInfo;
         pref = context.getSharedPreferences("ACCOUNT", MODE_PRIVATE);
         pref.edit().putString("email", email).apply();
         updateToken(authToken);
     }
 
-    public String getName() {
-        return name;
-    }
-    public void setName(String name) {
-        this.name = name;
-    }
-    public String getEmail() { return email; }
-    public String getAuthToken() {
-        return authToken;
-    }
-    public String getPermalink() { return permalink; }
-    public String getAbout() { return about; }
-    public String getGenre1() { return genre1; }
-    public String getGenre2() { return genre2; }
-    public String getGenre3() { return genre3; }
-    public String getProfilePic() { return profilePic; }
-    public String getBannerPic() { return bannerPic; }
+    public HashMap<String, String> getUserInfo() { return userInfo; }
 
-    public void updateToken(String authToken) {
-        this.authToken = authToken;
-        pref.edit().putString("token", authToken).apply();
-    }
-
-    public void updateEmail(String email) {
-        this.email = email;
-        pref.edit().putString("email", email).apply();
-    }
-    public void updateProfile(String name, String profilePic, String about, String genre1, String genre2, String genre3, String bannerPic) {
-        try {
-            JSONObject profilePicJson = new JSONObject(profilePic);
-            this.profilePic = profilePicJson.getString("url");
-            JSONObject bannerPicJson = new JSONObject(bannerPic);
-            this.bannerPic = bannerPicJson.getString("url");
-        } catch(JSONException e) {
-            e.printStackTrace();
+    public void updateUserInfo(Map<String, String> updateParams) {
+        for (Map.Entry<String, String> entry : updateParams.entrySet()) {
+            if (entry.getValue() != null) {
+                userInfo.put(entry.getKey(), entry.getValue());
+            }
         }
-        this.about = about;
-        this.genre1 = genre1;
-        this.genre2 = genre2;
-        this.genre3 = genre3;
     }
-    public void updateAccount(String email, String permalink) {
-        updateEmail(email);
-        this.permalink = permalink;
-    }
+
     public void logout() {
-        pref.edit().remove("email").apply();
         pref.edit().remove("token").apply();
     }
 }

--- a/app/src/main/java/com/thinqtv/thinqtv_android/data/model/LoggedInUser.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/data/model/LoggedInUser.java
@@ -19,8 +19,7 @@ public class LoggedInUser {
     public LoggedInUser(Context context, HashMap<String, String> userInfo) {
         this.userInfo = userInfo;
         pref = context.getSharedPreferences("ACCOUNT", MODE_PRIVATE);
-        pref.edit().putString("email", email).apply();
-        updateToken(authToken);
+        pref.edit().putString("token", userInfo.get("token")).apply();
     }
 
     public HashMap<String, String> getUserInfo() { return userInfo; }

--- a/app/src/main/java/com/thinqtv/thinqtv_android/profile_fragment.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/profile_fragment.java
@@ -60,6 +60,12 @@ public class profile_fragment extends Fragment {
             }
         });
 
+        Button scheduleConversationButton = view.findViewById(R.id.scheduleConversation);
+        scheduleConversationButton.setOnClickListener(v -> {
+            Intent intent = new Intent(getActivity(), AddEventActivity.class);
+            startActivity(intent);
+        });
+
         Spinner spinner = getView().findViewById(R.id.spinner2);
         ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(getContext(), R.array.ProfileSpinner, android.R.layout.simple_spinner_item);
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);

--- a/app/src/main/java/com/thinqtv/thinqtv_android/ui/auth/LoginActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/ui/auth/LoginActivity.java
@@ -31,6 +31,8 @@ import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import com.thinqtv.thinqtv_android.R;
 import com.thinqtv.thinqtv_android.data.DataSource;
 import com.thinqtv.thinqtv_android.data.UserRepository;
@@ -42,6 +44,7 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 import co.apptailor.googlesignin.RNGoogleSigninModule;
@@ -255,7 +258,8 @@ public class LoginActivity extends AppCompatActivity {
                     try {
                         Log.i(getString(R.string.google_sign_in_tag), "Signed in with Google.");
                         JSONObject user = new JSONObject(response.getString("user"));
-                        UserRepository.getInstance().setLoggedInUser(new LoggedInUser(context, response.getString("token"), user.getString("name"), user.getString("permalink")));
+                        user.put("token", response.getString("token"));
+                        UserRepository.getInstance().setLoggedInUser(new LoggedInUser(context, new Gson().fromJson(user.toString(), HashMap.class)));
                         setResult(Activity.RESULT_OK);
 
                         // Complete and destroy login activity only on a successful login.
@@ -300,7 +304,8 @@ public class LoginActivity extends AppCompatActivity {
                 try {
                     Log.i(getString(R.string.fb_sign_in_tag), "Signed in with FB");
                     JSONObject user = new JSONObject(response.getString("user"));
-                    UserRepository.getInstance().setLoggedInUser(new LoggedInUser(context, response.getString("token"), user.getString("name"), user.getString("permalink")));
+                    user.put("token", response.getString("token"));
+                    UserRepository.getInstance().setLoggedInUser(new LoggedInUser(context, new Gson().fromJson(user.toString(), HashMap.class)));
                     setResult(Activity.RESULT_OK);
 
                     // Complete and destroy login activity only on a successful login.

--- a/app/src/main/res/layout/activity_add_event.xml
+++ b/app/src/main/res/layout/activity_add_event.xml
@@ -6,6 +6,15 @@
     android:layout_height="match_parent"
     tools:context=".AddEventActivity">
 
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="?attr/actionBarTheme"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <TextView
         android:id="@+id/header"
         android:layout_width="wrap_content"
@@ -20,7 +29,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/toolbar" />
 
     <EditText
         android:id="@+id/event_title"

--- a/app/src/main/res/layout/profile_fragment.xml
+++ b/app/src/main/res/layout/profile_fragment.xml
@@ -23,7 +23,7 @@
         app:layout_constraintTop_toBottomOf="@+id/imageView" />
 
     <Button
-        android:id="@+id/schedConversat"
+        android:id="@+id/scheduleConversation"
         android:layout_width="310dp"
         android:layout_height="45dp"
         android:layout_marginTop="24dp"
@@ -48,7 +48,7 @@
         android:textSize="20sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/schedConversat" />
+        app:layout_constraintTop_toBottomOf="@+id/scheduleConversation" />
 
     <Spinner
         android:id="@+id/spinner2"


### PR DESCRIPTION
This may be too broad for one PR. ¯\\\_(ツ)_/¯
It will hopefully help address issues #51, #48, #47, #35, among other things.

Changes include:
- Users remain signed in when app is reopened.

- Screen name is no longer stored locally. The name is retrieved from the logged-in user.

- Event form has been updated to reflect changes to website.

- App should no longer crash when joining and exiting conferences.

- 'Schedule Conversation' button leads to the correct page.

- User info stored in hash.