### PR TITLE
Fix MainActivity crashing on orientation change

### DIFF
--- a/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
+++ b/app/src/main/java/com/thinqtv/thinqtv_android/MainActivity.java
@@ -28,6 +28,7 @@ public class MainActivity extends AppCompatActivity {
         startActivity(loadSavedUser);
 
         super.onCreate(savedInstanceState);
+        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         setContentView(R.layout.activity_main);
         bottomNavigation = findViewById(R.id.bottom_navigation);
         bottomNavigation.setOnNavigationItemSelectedListener(navigationItemSelectedListener);


### PR DESCRIPTION
Fix for #43. Just locked orientation on MainActivity