### PR TITLE
Rename Browse button again

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,7 +98,7 @@
     <string name="drop_in_room_name">DropIn</string>
     <string name="conversation_room_name">Conversation</string>
     <string name="control_panel">Control Panel</string>
-    <string name="browse_conversation_schedule">Browse Conversation Schedule</string>
+    <string name="browse_conversation_schedule">Browse Conversations</string>
     <string name="schedule_a_conversation">Schedule a Conversation</string>
     <string name="phone_number">6028883089</string>
 </resources>


### PR DESCRIPTION
Renaming the browse button in #61 got overridden, so this changes it to be shorter again.